### PR TITLE
Remove unnecessary file copy for vctk dataset

### DIFF
--- a/src/dataset/vctk.py
+++ b/src/dataset/vctk.py
@@ -135,7 +135,4 @@ class VCTK(Dataset):
         if not self.dev_mode:
             os.unlink(file_path)
 
-        shutil.copyfile(
-            os.path.join(dset_abs_path, "COPYING"),
-        )
         print('Done!')


### PR DESCRIPTION
To resolve issue #3 , this patch removes unnecessary file copy.